### PR TITLE
Bug fixes: historical data with descending order + JSON output for full historical data

### DIFF
--- a/investpy/bonds.py
+++ b/investpy/bonds.py
@@ -555,13 +555,9 @@ def get_bond_historical_data(bond, from_date, to_date, as_json=False, order='asc
                     result = result
 
                 if as_json is True:
-                    json_ = {
-                        'name': name,
-                        'historical':
-                            [value.bond_as_json() for value in result]
-                    }
-
-                    final.append(json_)
+                    json_list = [value.bond_as_json() for value in result]
+                    
+                    final.append(json_list)
                 elif as_json is False:
                     df = pd.DataFrame.from_records([value.bond_to_dict() for value in result])
                     df.set_index('Date', inplace=True)
@@ -574,7 +570,11 @@ def get_bond_historical_data(bond, from_date, to_date, as_json=False, order='asc
         final.reverse()
 
     if as_json is True:
-        return json.dumps(final[0], sort_keys=False)
+        json_ = {
+            'name': name,
+            'historical': [value for json_list in final for value in json_list]
+        }
+        return json.dumps(json_, sort_keys=False)
     elif as_json is False:
         return pd.concat(final)
 

--- a/investpy/bonds.py
+++ b/investpy/bonds.py
@@ -570,6 +570,9 @@ def get_bond_historical_data(bond, from_date, to_date, as_json=False, order='asc
         else:
             raise RuntimeError("ERR#0004: data retrieval error while scraping.")
 
+    if order in ['descending', 'desc']:
+        final.reverse()
+
     if as_json is True:
         return json.dumps(final[0], sort_keys=False)
     elif as_json is False:

--- a/investpy/certificates.py
+++ b/investpy/certificates.py
@@ -586,13 +586,9 @@ def get_certificate_historical_data(certificate, country, from_date, to_date, as
                     result = result
 
                 if as_json is True:
-                    json_ = {
-                        'name': name,
-                        'historical':
-                            [value.certificate_as_json() for value in result]
-                    }
+                    json_list = [value.certificate_as_json() for value in result]
                     
-                    final.append(json_)
+                    final.append(json_list)
                 elif as_json is False:
                     df = pd.DataFrame.from_records([value.certificate_to_dict() for value in result])
                     df.set_index('Date', inplace=True)
@@ -606,7 +602,11 @@ def get_certificate_historical_data(certificate, country, from_date, to_date, as
         final.reverse()
 
     if as_json is True:
-        return json.dumps(final[0], sort_keys=False)
+        json_ = {
+            'name': name,
+            'historical': [value for json_list in final for value in json_list]
+        }
+        return json.dumps(json_, sort_keys=False)
     elif as_json is False:
         return pd.concat(final)
 

--- a/investpy/certificates.py
+++ b/investpy/certificates.py
@@ -602,6 +602,9 @@ def get_certificate_historical_data(certificate, country, from_date, to_date, as
         else:
             raise RuntimeError("ERR#0004: data retrieval error while scraping.")
 
+    if order in ['descending', 'desc']:
+        final.reverse()
+
     if as_json is True:
         return json.dumps(final[0], sort_keys=False)
     elif as_json is False:

--- a/investpy/commodities.py
+++ b/investpy/commodities.py
@@ -631,6 +631,9 @@ def get_commodity_historical_data(commodity, from_date, to_date, country=None, a
         else:
             raise RuntimeError("ERR#0004: data retrieval error while scraping.")
 
+    if order in ['descending', 'desc']:
+        final.reverse()
+
     if as_json is True:
         return json.dumps(final[0], sort_keys=False)
     elif as_json is False:

--- a/investpy/commodities.py
+++ b/investpy/commodities.py
@@ -615,13 +615,9 @@ def get_commodity_historical_data(commodity, from_date, to_date, country=None, a
                     result = result
 
                 if as_json is True:
-                    json_ = {
-                        'name': name,
-                        'historical':
-                            [value.commodity_as_json() for value in result]
-                    }
-
-                    final.append(json_)
+                    json_list = [value.commodity_as_json() for value in result]
+                    
+                    final.append(json_list)
                 elif as_json is False:
                     df = pd.DataFrame.from_records([value.commodity_to_dict() for value in result])
                     df.set_index('Date', inplace=True)
@@ -635,7 +631,11 @@ def get_commodity_historical_data(commodity, from_date, to_date, country=None, a
         final.reverse()
 
     if as_json is True:
-        return json.dumps(final[0], sort_keys=False)
+        json_ = {
+            'name': name,
+            'historical': [value for json_list in final for value in json_list]
+        }
+        return json.dumps(json_, sort_keys=False)
     elif as_json is False:
         return pd.concat(final)
 

--- a/investpy/crypto.py
+++ b/investpy/crypto.py
@@ -557,6 +557,9 @@ def get_crypto_historical_data(crypto, from_date, to_date, as_json=False, order=
         else:
             raise RuntimeError("ERR#0004: data retrieval error while scraping.")
 
+    if order in ['descending', 'desc']:
+        final.reverse()
+
     if as_json is True:
         return json.dumps(final[0], sort_keys=False)
     elif as_json is False:

--- a/investpy/crypto.py
+++ b/investpy/crypto.py
@@ -542,13 +542,9 @@ def get_crypto_historical_data(crypto, from_date, to_date, as_json=False, order=
                     result = result
 
                 if as_json is True:
-                    json_ = {
-                        'name': crypto_name,
-                        'historical':
-                            [value.crypto_as_json() for value in result]
-                    }
+                    json_list = [value.crypto_as_json() for value in result]
                     
-                    final.append(json_)
+                    final.append(json_list)
                 elif as_json is False:
                     df = pd.DataFrame.from_records([value.crypto_to_dict() for value in result])
                     df.set_index('Date', inplace=True)
@@ -561,7 +557,11 @@ def get_crypto_historical_data(crypto, from_date, to_date, as_json=False, order=
         final.reverse()
 
     if as_json is True:
-        return json.dumps(final[0], sort_keys=False)
+        json_ = {
+            'name': crypto_name,
+            'historical': [value for json_list in final for value in json_list]
+        }
+        return json.dumps(json_, sort_keys=False)
     elif as_json is False:
         return pd.concat(final)
 

--- a/investpy/currency_crosses.py
+++ b/investpy/currency_crosses.py
@@ -604,6 +604,9 @@ def get_currency_cross_historical_data(currency_cross, from_date, to_date, as_js
         else:
             raise RuntimeError("ERR#0004: data retrieval error while scraping.")
 
+    if order in ['descending', 'desc']:
+        final.reverse()
+
     if as_json is True:
         return json.dumps(final[0], sort_keys=False)
     elif as_json is False:

--- a/investpy/currency_crosses.py
+++ b/investpy/currency_crosses.py
@@ -589,13 +589,9 @@ def get_currency_cross_historical_data(currency_cross, from_date, to_date, as_js
                     result = result
 
                 if as_json is True:
-                    json_ = {
-                        'name': name,
-                        'historical':
-                            [value.currency_cross_as_json() for value in result]
-                    }
-
-                    final.append(json_)
+                    json_list = [value.currency_cross_as_json() for value in result]
+                    
+                    final.append(json_list)
                 elif as_json is False:
                     df = pd.DataFrame.from_records([value.currency_cross_to_dict() for value in result])
                     df.set_index('Date', inplace=True)
@@ -608,7 +604,11 @@ def get_currency_cross_historical_data(currency_cross, from_date, to_date, as_js
         final.reverse()
 
     if as_json is True:
-        return json.dumps(final[0], sort_keys=False)
+        json_ = {
+            'name': name,
+            'historical': [value for json_list in final for value in json_list]
+        }
+        return json.dumps(json_, sort_keys=False)
     elif as_json is False:
         return pd.concat(final)
 

--- a/investpy/etfs.py
+++ b/investpy/etfs.py
@@ -719,6 +719,9 @@ def get_etf_historical_data(etf, country, from_date, to_date, stock_exchange=Non
         else:
             raise RuntimeError("ERR#0004: data retrieval error while scraping.")
 
+    if order in ['descending', 'desc']:
+        final.reverse()
+
     if as_json is True:
         return json.dumps(final[0], sort_keys=False)
     elif as_json is False:

--- a/investpy/etfs.py
+++ b/investpy/etfs.py
@@ -705,12 +705,9 @@ def get_etf_historical_data(etf, country, from_date, to_date, stock_exchange=Non
                     result = result
 
                 if as_json is True:
-                    json_ = {'name': name,
-                             'historical':
-                                 [value.etf_as_json() for value in result]
-                             }
+                    json_list = [value.etf_as_json() for value in result]
 
-                    final.append(json_)
+                    final.append(json_list)
                 elif as_json is False:
                     df = pd.DataFrame.from_records([value.etf_to_dict() for value in result])
                     df.set_index('Date', inplace=True)
@@ -723,7 +720,11 @@ def get_etf_historical_data(etf, country, from_date, to_date, stock_exchange=Non
         final.reverse()
 
     if as_json is True:
-        return json.dumps(final[0], sort_keys=False)
+        json_ = {
+            'name': name,
+            'historical': [value for json_list in final for value in json_list]
+        }
+        return json.dumps(json_, sort_keys=False)
     elif as_json is False:
         return pd.concat(final)
 

--- a/investpy/funds.py
+++ b/investpy/funds.py
@@ -578,12 +578,9 @@ def get_fund_historical_data(fund, country, from_date, to_date, as_json=False, o
                     result = result
 
                 if as_json is True:
-                    json_ = {'name': name,
-                             'historical':
-                                 [value.fund_as_json() for value in result]
-                             }
+                    json_list = [value.fund_as_json() for value in result]
 
-                    final.append(json_)
+                    final.append(json_list)
                 elif as_json is False:
                     df = pd.DataFrame.from_records([value.fund_to_dict() for value in result])
                     df.set_index('Date', inplace=True)
@@ -597,7 +594,11 @@ def get_fund_historical_data(fund, country, from_date, to_date, as_json=False, o
         final.reverse()
 
     if as_json is True:
-        return json.dumps(final[0], sort_keys=False)
+        json_ = {
+            'name': name,
+            'historical': [value for json_list in final for value in json_list]
+        }
+        return json.dumps(json_, sort_keys=False)
     elif as_json is False:
         return pd.concat(final)
 

--- a/investpy/funds.py
+++ b/investpy/funds.py
@@ -593,6 +593,9 @@ def get_fund_historical_data(fund, country, from_date, to_date, as_json=False, o
         else:
             raise RuntimeError("ERR#0004: data retrieval error while scraping.")
 
+    if order in ['descending', 'desc']:
+        final.reverse()
+
     if as_json is True:
         return json.dumps(final[0], sort_keys=False)
     elif as_json is False:

--- a/investpy/indices.py
+++ b/investpy/indices.py
@@ -601,6 +601,9 @@ def get_index_historical_data(index, country, from_date, to_date, as_json=False,
         else:
             raise RuntimeError("ERR#0004: data retrieval error while scraping.")
 
+    if order in ['descending', 'desc']:
+        final.reverse()
+
     if as_json is True:
         return json.dumps(final[0], sort_keys=False)
     elif as_json is False:

--- a/investpy/indices.py
+++ b/investpy/indices.py
@@ -587,12 +587,9 @@ def get_index_historical_data(index, country, from_date, to_date, as_json=False,
                     result = result
 
                 if as_json is True:
-                    json_ = {'name': name,
-                             'historical':
-                                 [value.index_as_json() for value in result]
-                             }
-
-                    final.append(json_)
+                    json_list = [value.index_as_json() for value in result]
+                    
+                    final.append(json_list)
                 elif as_json is False:
                     df = pd.DataFrame.from_records([value.index_to_dict() for value in result])
                     df.set_index('Date', inplace=True)
@@ -605,7 +602,11 @@ def get_index_historical_data(index, country, from_date, to_date, as_json=False,
         final.reverse()
 
     if as_json is True:
-        return json.dumps(final[0], sort_keys=False)
+        json_ = {
+            'name': name,
+            'historical': [value for json_list in final for value in json_list]
+        }
+        return json.dumps(json_, sort_keys=False)
     elif as_json is False:
         return pd.concat(final)
 

--- a/investpy/stocks.py
+++ b/investpy/stocks.py
@@ -612,6 +612,9 @@ def get_stock_historical_data(stock, country, from_date, to_date, as_json=False,
         else:
             raise RuntimeError("ERR#0004: data retrieval error while scraping.")
 
+    if order in ['descending', 'desc']:
+        final.reverse()
+
     if as_json is True:
         return json.dumps(final[0], sort_keys=False)
     elif as_json is False:

--- a/investpy/stocks.py
+++ b/investpy/stocks.py
@@ -596,13 +596,9 @@ def get_stock_historical_data(stock, country, from_date, to_date, as_json=False,
                     result = result
 
                 if as_json is True:
-                    json_ = {
-                        'name': name,
-                        'historical':
-                            [value.stock_as_json() for value in result]
-                    }
+                    json_list = [value.stock_as_json() for value in result]
                     
-                    final.append(json_)
+                    final.append(json_list)
                 elif as_json is False:
                     df = pd.DataFrame.from_records([value.stock_to_dict() for value in result])
                     df.set_index('Date', inplace=True)
@@ -616,7 +612,11 @@ def get_stock_historical_data(stock, country, from_date, to_date, as_json=False,
         final.reverse()
 
     if as_json is True:
-        return json.dumps(final[0], sort_keys=False)
+        json_ = {
+            'name': name,
+            'historical': [value for json_list in final for value in json_list]
+        }
+        return json.dumps(json_, sort_keys=False)
     elif as_json is False:
         return pd.concat(final)
 


### PR DESCRIPTION
This pull request fixes 2 bugs in the functions to get the historical data:

1. When `order='descending'`, the data is correctly ordered inside each date interval of 19 years but the date intervals are not ordered between them.
2. When `as_json=True`, only the first date interval (of 19 years) is returned instead of the full history.