### PR TITLE
Add billion in turnover

### DIFF
--- a/investpy/stocks.py
+++ b/investpy/stocks.py
@@ -1260,6 +1260,8 @@ def get_stocks_overview(country, as_json=False, n_results=100):
                 turnover = float(turnover.replace('K', '').replace(',', '')) * 1e3
             elif turnover.__contains__('M'):
                 turnover = float(turnover.replace('M', '').replace(',', '')) * 1e6
+            elif turnover.__contains__('B'):
+                turnover = float(turnover.replace('B', '').replace(',', '')) * 1e9
 
             data = {
                 "country": country_check,

--- a/tests/test_investpy.py
+++ b/tests/test_investpy.py
@@ -159,6 +159,11 @@ def test_investpy_stocks():
             'as_json': False,
             'n_results': 50
         }
+        {
+            'country': 'indonesia',
+            'as_json': False,
+            'n_results': 362
+        }
     ]
 
     for param in params:


### PR DESCRIPTION
Currently we can't parse turnover with value of B in get_stocks_overview and throwing error. `ValueError: invalid literal for int() with base 10: '2.59B'`

Example method call
```
investpy.get_stocks_overview(country="indonesia", n_results=1000)
```