### PR TITLE
Bugfix: stocks.get_stock_financial_summary raises ValueError and lxml.etree.ParserError

### DIFF
--- a/investpy/stocks.py
+++ b/investpy/stocks.py
@@ -1,7 +1,7 @@
 # Copyright 2018-2021 Alvaro Bartolome, alvarobartt @ GitHub
 # See LICENSE for details.
 
-from datetime import datetime, date, timedelta
+from datetime import datetime, timedelta
 import pytz
 
 from random import randint
@@ -20,7 +20,6 @@ from .utils.extra import random_user_agent
 from .utils.data import Data
 
 from .data.stocks_data import stocks_as_df, stocks_as_list, stocks_as_dict
-from .data.stocks_data import stock_countries_as_list
 
 
 def get_stocks(country=None):
@@ -1449,7 +1448,12 @@ def get_stock_financial_summary(stock, country, summary_type='income_statement',
                 curr_row = row.text_content().strip()
                 data[curr_row] = list()
                 continue
-            data[curr_row].append(float(row.text_content().strip()))
+
+            curr_value = row.text_content().strip()
+            if curr_value:
+                data[curr_row].append(float(curr_value))
+            else:
+                data[curr_row].append('N/A')
 
     dataset = pd.DataFrame(data)
     dataset.set_index('Date', inplace=True)

--- a/investpy/stocks.py
+++ b/investpy/stocks.py
@@ -1427,6 +1427,9 @@ def get_stock_financial_summary(stock, country, summary_type='income_statement',
     if req.status_code != 200:
         raise ConnectionError("ERR#0015: error " + str(req.status_code) + ", try again later.")
 
+    if not req.text:
+        raise RuntimeError('ERR#0139: no matching financial summary found.')
+
     root = fromstring(req.text)
     tables = root.xpath(".//div[@class='companySummaryIncomeStatement']\
         /table[contains(@class, 'companyFinancialSummaryTbl')]")

--- a/tests/test_investpy.py
+++ b/tests/test_investpy.py
@@ -201,6 +201,12 @@ def test_investpy_stocks():
             'country': 'united kingdom',
             'summary_type': 'cash_flow_statement',
             'period': 'annual'
+        },
+        {
+            'stock': 'blng',
+            'country': 'russia',
+            'summary_type': 'cash_flow_statement',
+            'period': 'quarterly'
         }
     ]
 


### PR DESCRIPTION
Hi!
I found several bugs in the stocks.get_stock_financial_summary function:

- if the table of the requested financial summary contains empty strings in values, ValueError is raised
- if the /instruments/Financials/changesummaryreporttypeajax endpoint returns an empty body, lxml.etree.ParserError is raised

Here is the fix.