### PR TITLE
🐛 Fix bug on `investpy.get_cryptos_overview`

### DIFF
--- a/investpy/crypto.py
+++ b/investpy/crypto.py
@@ -749,46 +749,51 @@ def get_cryptos_overview(as_json=False, n_results=100):
 
     flag = False
 
-    if len(table) > 0:
-        if n_results is not None and n_results <= 100:
-            table = table[:n_results]
-            flag = True
-        for row in table:
-            name = row.xpath(".//td[contains(@class, 'cryptoName')]")[0].text_content().strip()
-            symbol = row.xpath(".//td[contains(@class, 'symb')]")[0].get('title').strip()
-
-            tag = row.xpath(".//td[contains(@class, 'cryptoName')]/a")
-            
-            if len(tag) > 0:
-                status = 'available'
-            else:
-                status = 'unavailable'
-
-            price = row.xpath(".//td[contains(@class, 'price')]")[0].text_content()
-
-            market_cap = row.xpath(".//td[@class='js-market-cap']")[0].get('data-value')
-            volume24h = row.xpath(".//td[@class='js-24h-volume']")[0].get('data-value')
-            total_volume = row.xpath(".//td[@class='js-total-vol']")[0].text_content()
-
-            change24h = row.xpath(".//td[contains(@class, 'js-currency-change-24h')]")[0].text_content()
-            change7d = row.xpath(".//td[contains(@class, 'js-currency-change-7d')]")[0].text_content()
-
-            data = {
-                "name": name,
-                "symbol": symbol,
-                "status": status,
-                "price": float(price.replace(',', '')),
-                "market_cap": float(market_cap.replace(',', '')),
-                "volume24h": volume24h,
-                "total_volume": total_volume,
-                "change24h": change24h,
-                "change7d": change7d,
-                "currency": "USD"
-            }
-
-            results.append(data)
-    else:
+    if len(table) < 1:
         raise RuntimeError("ERR#0092: no data found while retrieving the overview from Investing.com")
+    
+    if n_results is not None and n_results <= 100:
+        table = table[:n_results]
+        flag = True
+    
+    for row in table:
+        name = row.xpath(".//td[contains(@class, 'cryptoName')]")[0].text_content().strip()
+        symbol = row.xpath(".//td[contains(@class, 'symb')]")[0].get('title').strip()
+
+        # Due to Investing.com parsing error
+        if symbol in ["GRV", "GLYPH"]:
+            continue
+
+        tag = row.xpath(".//td[contains(@class, 'cryptoName')]/a")
+        
+        if len(tag) > 0:
+            status = 'available'
+        else:
+            status = 'unavailable'
+
+        price = row.xpath(".//td[contains(@class, 'price')]")[0].text_content()
+
+        market_cap = row.xpath(".//td[@class='js-market-cap']")[0].get('data-value')
+        volume24h = row.xpath(".//td[@class='js-24h-volume']")[0].get('data-value')
+        total_volume = row.xpath(".//td[@class='js-total-vol']")[0].text_content()
+
+        change24h = row.xpath(".//td[contains(@class, 'js-currency-change-24h')]")[0].text_content()
+        change7d = row.xpath(".//td[contains(@class, 'js-currency-change-7d')]")[0].text_content()
+
+        data = {
+            "name": name,
+            "symbol": symbol,
+            "status": status,
+            "price": float(price.replace(',', '')),
+            "market_cap": float(market_cap.replace(',', '')),
+            "volume24h": volume24h,
+            "total_volume": total_volume,
+            "change24h": change24h,
+            "change7d": change7d,
+            "currency": "USD"
+        }
+
+        results.append(data)
 
     if flag is True:
         df = pd.DataFrame(results)
@@ -821,43 +826,47 @@ def get_cryptos_overview(as_json=False, n_results=100):
             remaining_cryptos = n_results - len(results)
             table = table[:remaining_cryptos]
 
-        if len(table) > 0:
-            for row in table:
-                name = row.xpath(".//td[contains(@class, 'cryptoName')]")[0].text_content().strip()
-                symbol = row.xpath(".//td[contains(@class, 'symb')]")[0].get('title').strip()
-
-                tag = row.xpath(".//td[contains(@class, 'cryptoName')]/a")
-            
-                if len(tag) > 0:
-                    status = 'available'
-                else:
-                    status = 'unavailable'
-
-                price = row.xpath(".//td[contains(@class, 'price')]")[0].text_content()
-
-                market_cap = row.xpath(".//td[@class='js-market-cap']")[0].get('data-value')
-                volume24h = row.xpath(".//td[@class='js-24h-volume']")[0].get('data-value')
-                total_volume = row.xpath(".//td[@class='js-total-vol']")[0].text_content()
-
-                change24h = row.xpath(".//td[contains(@class, 'js-currency-change-24h')]")[0].text_content()
-                change7d = row.xpath(".//td[contains(@class, 'js-currency-change-7d')]")[0].text_content()
-
-                data = {
-                    "name": name,
-                    "symbol": symbol,
-                    "status": status,
-                    "price": float(price.replace(',', '')),
-                    "market_cap": float(market_cap.replace(',', '')),
-                    "volume24h": volume24h,
-                    "total_volume": total_volume,
-                    "change24h": change24h,
-                    "change7d": change7d,
-                    "currency": "USD"
-                }
-
-                results.append(data)
-        else:
+        if len(table) < 1:
             raise RuntimeError("ERR#0092: no data found while retrieving the overview from Investing.com")
+        
+        for row in table:
+            name = row.xpath(".//td[contains(@class, 'cryptoName')]")[0].text_content().strip()
+            symbol = row.xpath(".//td[contains(@class, 'symb')]")[0].get('title').strip()
+
+            # Due to Investing.com parsing error
+            if symbol in ["GRV", "GLYPH"]:
+                continue
+
+            tag = row.xpath(".//td[contains(@class, 'cryptoName')]/a")
+        
+            if len(tag) > 0:
+                status = 'available'
+            else:
+                status = 'unavailable'
+
+            price = row.xpath(".//td[contains(@class, 'price')]")[0].text_content()
+
+            market_cap = row.xpath(".//td[@class='js-market-cap']")[0].get('data-value')
+            volume24h = row.xpath(".//td[@class='js-24h-volume']")[0].get('data-value')
+            total_volume = row.xpath(".//td[@class='js-total-vol']")[0].text_content()
+
+            change24h = row.xpath(".//td[contains(@class, 'js-currency-change-24h')]")[0].text_content()
+            change7d = row.xpath(".//td[contains(@class, 'js-currency-change-7d')]")[0].text_content()
+
+            data = {
+                "name": name,
+                "symbol": symbol,
+                "status": status,
+                "price": float(price.replace(',', '')),
+                "market_cap": float(market_cap.replace(',', '')),
+                "volume24h": volume24h,
+                "total_volume": total_volume,
+                "change24h": change24h,
+                "change7d": change7d,
+                "currency": "USD"
+            }
+
+            results.append(data)
 
     df = pd.DataFrame(results)
 


### PR DESCRIPTION
Sometimes when using `investpy.get_cryptos_overview` with the parameter `n_results` set to `None`, when retrieving all the available cryptos indexed in Investing.com at https://www.investing.com/crypto/currencies, an issue happens while trying to convert both the `price` and `market_cap` values for some cryptos.

This issue is due to an Investing.com error while showing the information for those cryptocurrencies, since their values exceed 1M, so that the API doesn't return it in a float-readable format.

It affects the following cryptocurrencies:
- GLYPH Vault (NFTX) - GLYPH
- Gravitoken - GRV

One solution could be to just remove the dots of e.g. `1.238.990` and convert it to `float` just for the cryptocurrencies that we know are failing, but as we're providing information about real data, it's preferable to omit it rather than providing incorrect data.