### PR TITLE
Remove duplicate stocks in Japan

### DIFF
--- a/investpy/resources/stocks.csv
+++ b/investpy/resources/stocks.csv
@@ -26312,13 +26312,11 @@ japan,Nippon Concrete Industry,Nippon Concrete Industries Co Ltd,nippon-concrete
 japan,Mitani Sekisan,Mitani Sekisan Co Ltd,mitani-sekisan,JP3887600009,952215,JPY,5273
 japan,Japan Pile Corp,Japan Pile Corp,japan-pile-corp,JP3389640008,952216,JPY,5288
 japan,Nippon Carbon,Nippon Carbon Co Ltd,nippon-carbon,JP3690400001,952217,JPY,5302
-japan,Toyota Motor,Toyota Motor Corp,toyota-motor-corporation?cid=44137,JP3633400001,44137,JPY,7203
 japan,Recruit Holdings,Recruit Holdings Co Ltd,recruit-holdings,JP3970300004,952303,JPY,6098
 japan,Japan Post Holdings,Japan Post Holdings Co Ltd,japan-post-holdings-co-ltd,JP3752900005,959213,JPY,6178
 japan,Haseko,Haseko Corp,haseko-corp,JP3768600003,969277,JPY,1808
 japan,Sumitomo Mitsui,Sumitomo Mitsui Trust Holdings,sumitomo-mitsui-trust-holdings,JP3892100003,969280,JPY,8309
 japan,Concordia Financial Group,Concordia Financial Group Ltd,concordia-financial-group-ltd,JP3305990008,976159,JPY,7186
-japan,Seiko Epson Cor,Seiko Epson Corp,seiko-epson-cor?cid=1089699,JP3414750004,1089699,JPY,6724
 japan,Axas Holdings Co,Axas Holdings Co Ltd,axas-holdings-co-ltd,JP3108160007,969033,JPY,3536
 japan,Shoei Yakuhin Co,Shoei Yakuhin Co Ltd,shoei-yakuhin-co-ltd,JP3361400009,969034,JPY,3537
 japan,CHIeru Co,CHIeru Co Ltd,chieru-co-ltd,JP3507650004,969038,JPY,3933
@@ -27078,7 +27076,6 @@ japan,Nojima,Nojima Corp,nojima-corp,JP3761600000,992218,JPY,7419
 japan,Japan Lifeline,Japan Lifeline Co Ltd,japan-lifeline-co-ltd,JP3754500001,992261,JPY,7575
 japan,Asahi Intecc,Asahi Intecc Co Ltd,asahi-intecc-co-ltd,JP3110650003,992296,JPY,7747
 japan,Kusuri No Aoki Holdings Co Ltd,Kusuri No Aoki Holdings Co Ltd,kusuri-no-aoki-holdings-co-ltd,JP3266190002,993287,JPY,3549
-japan,Sumitomo Mitsui,Sumitomo Mitsui Trust Holdings,sumitomo-mitsui-trust-holdings?cid=44297,JP3892100003,44297,JPY,8309
 japan,Amano Corp,Amano Corp,amano-corp,JP3124400007,952375,JPY,6436
 japan,Nippon Sharyo Ltd,Nippon Sharyo Ltd,nippon-sharyo-ltd,JP3713600009,952493,JPY,7102
 japan,Avex Group Holdings,Avex Group Holdings Inc,avex-group-holdings,JP3160950006,952629,JPY,7860


### PR DESCRIPTION
Remove duplicate stocks in Japan.
Toyota Motors has an invalid id.
