### PR TITLE
Add new types in type_values of stocks.get_stock_dividends

### DIFF
--- a/investpy/stocks.py
+++ b/investpy/stocks.py
@@ -1061,6 +1061,8 @@ def get_stock_dividends(stock, country):
             "3": "semi_annual",
             "4": "annual",
             "5": "trailing_twelve_months",
+            "6": "interim",
+            "7": "other",
         }
 
         if path_:


### PR DESCRIPTION
This fix add new types in `type_values` which are being returned when search for dividends of Brazilian stocks. 

Example (https://www.investing.com/equities/vale-on-n1-dividends):
```
<tr event_timestamp="1614902400">
<td class="left first" data-value="1614902400">Mar 05, 2021</td>
<td>0.8357368</td>
<td data-value="6" class="textNum left">
<span class="iconOther" title="Other"></span>
</td>
<td data-value="1615766400">Mar 15, 2021</td>
<td>6.75%</td>
</tr>
<tr event_timestamp="1614902400">
<td class="left first" data-value="1614902400">Mar 05, 2021</td>
<td>3.4259103</td>
<td data-value="7" class="textNum left">
<span class="iconInterim" title="Interim"></span>
</td>
<td data-value="1615766400">Mar 15, 2021</td>
<td>6.75%</td>
</tr>
```

IMO, those `type_values` shouldn't be linked to a dictionary, the values must be a lowercase of _span.title_. This will avoid problems in the future when Investing.com defines new unexpected types