### PR TITLE
Handle error if some information is missing

### DIFF
--- a/investpy/stocks.py
+++ b/investpy/stocks.py
@@ -1745,7 +1745,10 @@ def get_stock_financial_summary(
                 curr_row = row.text_content().strip()
                 data[curr_row] = list()
                 continue
+            try:
             data[curr_row].append(float(row.text_content().strip()))
+            except ValueError: #Missing values get ignored
+                data[curr_row].append(float('nan'))
 
     dataset = pd.DataFrame(data)
     dataset.set_index("Date", inplace=True)


### PR DESCRIPTION
Hi all, 

so far, if there is financial information missing e.g. earnings like in:
https://www.investing.com/equities/glencore-financial-summary

<img width="518" alt="image" src="https://user-images.githubusercontent.com/32644386/188604938-114c7870-1525-4b2a-af4f-9e180d55b140.png">

the investpy tries to convert them to float and raises an error, I've added a try block to display nans instead. I think it's fair to let the user decide if nans are okay values and raise an error on their side instead of introducing error='surpass' argument.

Happy to discuss.

Best

Dani
